### PR TITLE
lab-setup.azcli

### DIFF
--- a/Instructions/Labs/LAB_AK_10-analyze-time-stamped-data-with-time-series-insights.md
+++ b/Instructions/Labs/LAB_AK_10-analyze-time-stamped-data-with-time-series-insights.md
@@ -51,9 +51,9 @@ This lab assumes the following resources are available:
 1. To create a directory for this lab, move **lab-setup.azcli** into that directory, and make that the current working directory, enter the following commands:
 
     ```bash
-    mkdir lab9
-    mv lab-setup.azcli lab9
-    cd lab9
+    mkdir lab10
+    mv lab10-setup.azcli lab10
+    cd lab10
     ```
 
 1. To ensure the **lab-setup.azcli** has the execute permission, enter the following commands:


### PR DESCRIPTION
In that case, we are in lab10 and, even it is not really important, you name the directory lab9, what was the previous lab. In general, in all Exercise 1: Verify Lab Prerequisites, you write "lab-setup.azcli", but the names of the files in the paths   "AZ-220-Microsoft-Azure-IoT-Developer/Allfiles/Labs/{LAB#}/Setup/ you usually name lab{LAB#}-setup.azcli

# Module: 05
## Lab/Demo: 10

Fixes # .

Changes proposed in this pull request:

-
-
-