### PR TITLE
Update 04-Debug-IoT-Edge-Simulator.md

### DIFF
--- a/MSLearn/Modules/L13-deploy-and-debug-custom-azure-iot-edge-module/04-Debug-IoT-Edge-Simulator.md
+++ b/MSLearn/Modules/L13-deploy-and-debug-custom-azure-iot-edge-module/04-Debug-IoT-Edge-Simulator.md
@@ -28,7 +28,7 @@ In this unit, you will build and run a custom IoT Edge Module solution using the
 
 1. Open the **IoT Edge Solution** for the custom IoT Edge Module with **Visual Studio Code**.
 
-1. Within the **Explorer** pane, right-click the `deployment.debug.manifest.json` debugging deployment manifest file in the root directory of the IoT Edge Solution.
+1. Within the **Explorer** pane, right-click the `deployment.debug.template.json` debugging deployment manifest file in the root directory of the IoT Edge Solution.
 
 1. Select the **Build and Run IoT Edge Solution in Simulator** option.
 


### PR DESCRIPTION
# Module: 13
## Lab/Demo: 04

Fixes # .

Changed the name of the debug deployment file from deployment.debug.manifest.json into deployment.debug.template.json, since this is how it shows in VS Code.

Changes proposed in this pull request:

Also, in the lab description there is an explanation on how the password is needed in the terminal window because elevated privileges are needed. This is only true if the terminal is configured as bash shell, if the terminal is a Windows PowerShell window, it will execute the simulator configuration without prompting for a password.
