### PR TITLE
OnDesiredPropertyChanged code change suggestion.

### DIFF
--- a/Instructions/Labs/LAB_AK_05-individual-enrollment-of-device-in-dps.md
+++ b/Instructions/Labs/LAB_AK_05-individual-enrollment-of-device-in-dps.md
@@ -271,7 +271,7 @@ This is different than the earlier lab where a simulated device connected to Azu
 
         // Report Twin Properties
         var reportedProperties = new TwinCollection();
-        reportedProperties["telemetryDelay"] = this._telemetryDelay;
+        reportedProperties["telemetryDelay"] = this._telemetryDelay.ToString();
         await iotClient.UpdateReportedPropertiesAsync(reportedProperties).ConfigureAwait(false);
         Console.WriteLine("Reported Twin Properties:");
         Console.WriteLine($"{reportedProperties.ToJson()}");

--- a/MSLearn/Modules/L05-individual-enrollment-of-device-in-dps/02-Configure-Simulated-Device.md
+++ b/MSLearn/Modules/L05-individual-enrollment-of-device-in-dps/02-Configure-Simulated-Device.md
@@ -63,7 +63,7 @@ The simulated device created in this unit is for a an asset tracking solution th
 
         // Report Twin Properties
         var reportedProperties = new TwinCollection();
-        reportedProperties["telemetryDelay"] = this._telemetryDelay;
+        reportedProperties["telemetryDelay"] = this._telemetryDelay.ToString();
         await iotClient.UpdateReportedPropertiesAsync(reportedProperties).ConfigureAwait(false);
         Console.WriteLine("Reported Twin Properties:");
         Console.WriteLine($"{reportedProperties.ToJson()}");


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 05

Fixes # .

Changes proposed in this pull request:

Suggestion to make the desired and reported properties in method **OnDesiredPropertyChanged** the same. In the sample, desired is passed as a string, reported is send as an integer. Even though it compiles and works, I suggest to send the reported property as a string as well to keep reported and desired properties consistent.
