### PR TITLE
Change s_iotHubSasKeyName = "iothubowner";

### DIFF
--- a/Instructions/Labs/LAB_AK_15-remotely-monitor-and-control-devices.md
+++ b/Instructions/Labs/LAB_AK_15-remotely-monitor-and-control-devices.md
@@ -446,7 +446,7 @@ This section adds code to receive telemetry from the IoT Hub Event Hub endpoint.
             // The Event Hub-compatible name.
             private readonly static string s_eventHubsCompatiblePath = "<your event hub path>";
             private readonly static string s_iotHubSasKey = "<your event hub Sas key>";
-            private readonly static string s_iotHubSasKeyName = "service";
+            private readonly static string s_iotHubSasKeyName = "iothubowner";
             private static EventHubClient s_eventHubClient;
 
             // Connection string for your IoT Hub.


### PR DESCRIPTION
I got token errors when using the existing s_iotHubSasKeyName = "service";  in the 'ReceiveTelemetry' solution.
It works correctly now I've made this change.

# Module: 00
## Lab/Demo: 15

Fixes # .

Changes proposed in this pull request:

-
-
-