### PR TITLE
Fix the Azure Billing FAQs section name

### DIFF
--- a/Instructions/Labs/LAB_AK_01-getting-started-with-azure.md
+++ b/Instructions/Labs/LAB_AK_01-getting-started-with-azure.md
@@ -127,11 +127,11 @@ Although Azure commonly referred to as a 'cloud', it is actually a web portal th
 
 1. On the toolbar, click **Help**, and then click **Help + support**
 
-1. On the **Help + support** blade, notice the four Tiles for _Getting started_, _Documentation_, _Learn about billing_, and _Support plans_.
+1. On the **Help + support** blade, notice the four Tiles for _Getting started_, _Documentation_, _Billing FAQs_, and _Support plans_.
 
     The Help + support blade gives you access to lots of great resources. You may want to come back to this later for further exploration.
 
-1. On the **Help + support** blade, click **Learn about billing**
+1. On the **Help + support** blade, click **Billing FAQs**
 
     A new browser tab should open to display Azure billing documentation.
 


### PR DESCRIPTION
Use the current Azure Billing FAQs section name in Azure Portal >> All Services >> Help and Support

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

Use the current Azure Billing FAQs section name in Azure Portal >> All Services >> Help and Support

https://portal.azure.com/#blade/Microsoft_Azure_Support/HelpAndSupportBlade/overview
-
-
-