### PR TITLE
Changed field label for storage account

### DIFF
--- a/Instructions/Labs/LAB_AK_11-introduction-to-azure-iot-edge.md
+++ b/Instructions/Labs/LAB_AK_11-introduction-to-azure-iot-edge.md
@@ -715,7 +715,7 @@ Now that the tempSensor module is deployed and running on the IoT Edge device, w
 
 1. Set the **Location** field to the same Azure Region used for Azure IoT Hub.
 
-1. Set the **Replication** field to **Locally-redundant storage (LRS)**.
+1. Set the **Redundancy** field to **Locally-redundant storage (LRS)**.
 
 1. Leave all other settings unchanged.
 


### PR DESCRIPTION
Changed field label from "Replication" to "Redundancy" for the creation of the storage account.

# Module: 06
## Lab: 11

Changes proposed in this pull request:

- Changed field label to Redundancy for the creation of the storage account