### PR TITLE
Exercise 6 -> Task 1 -> Step 12: Updated steps

### DIFF
--- a/Instructions/Labs/LAB_AK_14-iot-edge-device-in-restricted-network.md
+++ b/Instructions/Labs/LAB_AK_14-iot-edge-device-in-restricted-network.md
@@ -759,7 +759,7 @@ In this exercise, you will use the Azure Portal user interface for Azure IoT Hub
 
 1. On the **Set modules** blade, under **Iot Edge Modules**, click **Runtime Settings**.
 
-1. On the **Runtime Settings** pane, locate the **Store and forward configuration - time to live (seconds)** field.
+1. On the **Runtime Settings** pane, click the **Edge Hub** tab, then locate the **Store and forward configuration - time to live (seconds)** field.
 
 1. In the **Store and forward configuration - time to live (seconds)** textbox, enter **1209600**
 


### PR DESCRIPTION
Added information: "click the **Edge Hub** tab"

Complete step:
1. On the **Runtime Settings** pane, click the **Edge Hub** tab, then locate the **Store and forward configuration - time to live (seconds)** field.

# Module: 07
## Lab/Demo: 14

Fixes # .

Changes proposed in this pull request:

- Added "click the **Edge Hub** tab" to Exercise 6 -> Task 1 -> Step 12.
-
-