### PR TITLE
Proposed wording change & command case mistake

### DIFF
--- a/Instructions/Labs/LAB_AK_19-azure-digital-twins.md
+++ b/Instructions/Labs/LAB_AK_19-azure-digital-twins.md
@@ -113,9 +113,9 @@ To ensure these resources are available, complete the following steps.
 
 The resources have now been created.
 
-#### Task 2 - Verify tools
+#### Task 2 - Verify lab tool versions
 
-1. In your virtual machine environment, open a Windows Command Prompt window.
+1. In your lab environment, open a Windows Command Prompt window.
 
 1. To display the version of Azure CLI that is installed locally, enter the following command:
 

--- a/Instructions/Labs/LAB_AK_19-azure-digital-twins.md
+++ b/Instructions/Labs/LAB_AK_19-azure-digital-twins.md
@@ -89,7 +89,7 @@ To ensure these resources are available, complete the following steps.
 1. To determine the current user ID, open the **Cloud Shell** and execute the following command:
 
     ```sh
-    az ad signed-in-user show --query Id -o tsv
+    az ad signed-in-user show --query id -o tsv
     ```
 
     Copy the displayed object ID.


### PR DESCRIPTION
In our lab at the top was a disclaimer, above the rending of this markdown (i don't see it in the markdown) it said - ..'Please use this resource group when creating the virtual machine'.   This confused me when I got to Task 2, as I thought we had to create a VM, and when I went to do this (bear in mind this is the tail end of the course when we are tired!) I went to the marketplace to make one and policy stopped me.  I was confused until someone point out the lab environment was a VM!   Suggested rewording for clarity

# Module: 19
## Lab/Demo: 16

Fixes # .

Changes proposed in this pull request:

Wording to remove reference to virtual machine (which is confusing when related labs involved provisioning one)